### PR TITLE
Allow downloading multiple tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Import-Module $destination -Force
 
 Get-SPTool               # list tools with descriptions
 
-Get-SPTool "Procmon" -Download               # download specific tool
-Get-SPTool -DownloadAll -Source Official      # fetch everything from official sources
-Get-SPTool "Procmon" -Download -Source Internal  # fetch from internal source
+Get-SPTool -Name 'Procmon','ULS Viewer' -Download    # download specific tools
+Get-SPTool -DownloadAll -Source Official             # fetch everything from official sources
+Get-SPTool -Name 'Procmon' -Download -Source Internal  # fetch from internal source
 
 By default, downloads are placed in a "E:\SpToolbox\". Override this location with the `-Destination` parameter.


### PR DESCRIPTION
## Summary
- Allow `Get-SPTool` to accept and download multiple tool names
- Update module and README examples to demonstrate multi-tool usage

## Testing
- `pwsh -NoLogo -Command "Split-Path -Path '/tmp/SpToolbox/' -Qualifier"` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689277c7a68083329c3939a6090dc17a