### PR TITLE
Fix drive letter prompt in Get-SPTool

### DIFF
--- a/SPToolbox.psm1
+++ b/SPToolbox.psm1
@@ -152,7 +152,7 @@ function Get-SPTool {
         $maxAttempts = 3
         for ($i = 0; $i -lt $maxAttempts; $i++) {
             $prompt = "Enter the drive letter for the toolbox (use -Destination for a full path)"
-            $letter = Read-Host $prompt
+            $letter = (Read-Host $prompt).Trim().TrimEnd(':')
 
             if ($letter -notmatch '^[A-Za-z]$') {
                 Write-Host "Please enter a single drive letter (e.g. C or D)."


### PR DESCRIPTION
## Summary
- trim user-supplied drive letters in `Get-SPTool` so prompts accept input like `D:` or `d`

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68927bc0dcd48332abaaa9f97bc2806a